### PR TITLE
WIP: refactor: Replace backup shell script with Python

### DIFF
--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -120,9 +120,9 @@ spec:
                 - name: S3_BUCKET_NAME
                   value: '{{ BACKUP_S3_BUCKET_NAME }}'
               command:
-                - '/bin/bash'
-                - '-c'
-                - 'backup_services.sh && python upload_to_s3.py'
+                - 'python'
+                - 'backup_services.py'
+                - '--upload'
           {% if ENABLE_WEB_PROXY %}
               volumeMounts:
                 - mountPath: /caddy/

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -49,7 +49,7 @@ def backup(context):
     job_runner = context.job_runner(config)
     job_runner.run_job(
         service="backup",
-        command="bash backup_services.sh"
+        command="python backup_services.py"
     )
 
 
@@ -76,7 +76,7 @@ def restore(context):
 def backup(context):  # noqa: F811
     config = tutor_config.load(context.root)
     job_runner = K8sJobRunner(context.root, config)
-    command = "/bin/bash -c backup_services.sh && python upload_to_s3.py"
+    command = "python backup_services.py --upload"
     job_runner.run_job(service="backup-restore", command=command)
 
 

--- a/tutorbackup/templates/backup/build/backup/backup_services.py
+++ b/tutorbackup/templates/backup/build/backup/backup_services.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+from subprocess import check_call
+
+import click
+
+import glob
+import logging
+import os
+import shutil
+import sys
+import tarfile
+
+ENV = os.environ
+
+DUMP_DIRECTORY = '/data'
+
+MYSQL_DUMPFILE = os.path.join(DUMP_DIRECTORY, 'mysql_dump.sql')
+MONGODB_DUMPDIR = os.path.join(DUMP_DIRECTORY, 'mongodb_dump')
+CADDY_DUMPDIR = os.path.join(DUMP_DIRECTORY, 'caddy')
+
+TARFILE = '/backup/backup.tar.xz'
+
+logger = logging.getLogger(__name__)
+
+
+def mysqldump():
+    user = ENV['MYSQL_ROOT_USERNAME']
+    password = ENV['MYSQL_ROOT_PASSWORD']
+    host = ENV['MYSQL_HOST']
+    port = ENV['MYSQL_PORT']
+    outfile = MYSQL_DUMPFILE
+
+    logger.info(f"Dumping MySQL databases on {host}:{port} to {outfile}")
+    cmd = ("mysqldump "
+           "--all-databases --single-transaction "
+           "--quick --quote-names --max-allowed-packet=16M "
+           f"--host={host} --port={port} "
+           f"--user={user} --password={password}")
+    with open(outfile, 'wb') as out:
+        check_call(cmd,
+                   stdout=out,
+                   stderr=sys.stderr)
+
+    size = os.path.getsize(outfile)
+    logger.info(f"Complete. {outfile} is {size} bytes.")
+
+
+def mongodump():
+    host = ENV['MONGODB_HOST']
+    port = ENV['MONGODB_PORT']
+    outdir = MONGODB_DUMPDIR
+
+    logger.info(f"Dumping MongoDB databases on {host}:{port} to {outdir}")
+    cmd = ("mongodump "
+           f"--out={outdir} "
+           f"--host={host} "
+           f"--port={port}")
+    check_call(cmd,
+               stdout=sys.stdout,
+               stderr=sys.stderr)
+
+    files = os.listdir(outdir)
+    num_files = len(files)
+    total_size = sum([os.path.getsize(f) for f in files])
+    logger.info(f"Complete. {outdir} contains {num_files} file(s), "
+                f"total size {total_size} bytes.")
+
+
+def caddydump():
+    outdir = CADDY_DUMPDIR
+
+    logger.info(f"Copying Caddy data to {outdir}")
+    shutil.copytree('caddy', outdir)
+
+    files = [path for path in glob.glob(os.path.join(outdir, '**'))]
+    num_files = len(files)
+    total_size = sum([os.path.getsize(f) for f in files])
+    logger.info(f"Complete. {outdir} contains {num_files} file(s), "
+                f"total size {total_size} bytes.")
+
+
+def archive():
+    paths = [MYSQL_DUMPFILE, MONGODB_DUMPDIR, CADDY_DUMPDIR]
+    outfile = TARFILE
+
+    logger.info(f"Creating archive {outfile}")
+    with tarfile.open(outfile, "w:xz") as tar:
+        for item in paths:
+            tar.add(item)
+
+    size = os.path.getsize(outfile)
+    logger.info(f"Complete. {outfile} is {size} bytes.")
+
+
+def upload():
+    from .s3_client import S3_CLIENT
+
+    bucket = ENV['S3_BUCKET_NAME']
+    file_name = TARFILE
+
+    logger.info(f"Uploading {file_name} to S3 bucket {bucket}")
+    S3_CLIENT.upload_file(
+        file_name,
+        bucket,
+        os.path.basename(file_name),
+    )
+    # FIXME: Apparently: upload_file() doesn't return anything useful
+    # in the response. It either succeeds, or fails and throws an
+    # exception. We probably want to fetch some object metadata after
+    # the upload, to check for a size match.
+    logger.info("Complete.")
+
+
+@click.command()
+@click.option('--upload', is_flag=True, help="Upload to S3")
+def main(upload):
+    loglevel = logging.INFO
+    try:
+        loglevel = getattr(logging, ENV['LOG_LEVEL'].upper())
+    except KeyError:
+        pass
+    logger.setLevel(loglevel)
+
+    mysqldump()
+    mongodump()
+    caddydump()
+    archive()
+
+    if upload:
+        upload()
+
+
+if __name__ == '__main__':
+    main()

--- a/tutorbackup/templates/backup/build/backup/backup_services.sh
+++ b/tutorbackup/templates/backup/build/backup/backup_services.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-mysqldump --all-databases --single-transaction --quick --quote-names --max-allowed-packet=16M \
-  --password=$MYSQL_ROOT_PASSWORD --user=$MYSQL_ROOT_USERNAME --host=$MYSQL_HOST --port=$MYSQL_PORT > /data/mysql_dump.sql
-mongodump --out=/data/mongodb_dump --host=$MONGODB_HOST --port=$MONGODB_PORT
-cp -r caddy/ data/
-tar --exclude='/data/caddy/locks' -Jcvf /backup/backup.tar.xz /data/


### PR DESCRIPTION
This is an attempt to use a Python backup script, rather than a Bash script. This gives us better logging, is easier to write test code for, and also facilitates integration with S3 upload.

@foadlind: I had a go at this last night while testing, just to see if it might make sense. I don't know if it does, yet, but it might end up making the backup a little more integrated. This is definitely not perfect, and will still need work, but we might also throw it out altogether.

Let me know what you think. No hard feelings at all if you want to discard this. :)