### PR TITLE
refactor: Replace restore shell script with Python

### DIFF
--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -203,7 +203,7 @@ spec:
                 - name: S3_BUCKET_NAME
                   value: '{{ BACKUP_S3_BUCKET_NAME }}'
               command: ["/bin/sh", "-c"]
-              args: ["python download_from_s3.py && bash restore_services.sh"]
+              args: ["python restore_services.py --download{% if not ENABLE_WEB_PROXY %} --exclude=caddy{% endif %}"]
           {% if ENABLE_WEB_PROXY %}
               volumeMounts:
                 - mountPath: /caddy/

--- a/tutorbackup/templates/backup/build/backup/Dockerfile
+++ b/tutorbackup/templates/backup/build/backup/Dockerfile
@@ -12,7 +12,6 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.2.asc | gpg --dearmor
     mkdir data backup
 
 COPY backup_services.py .
-COPY restore_services.sh .
-
+COPY restore_services.py .
 COPY s3_client.py .
-COPY download_from_s3.py .
+

--- a/tutorbackup/templates/backup/build/backup/s3_client.py
+++ b/tutorbackup/templates/backup/build/backup/s3_client.py
@@ -19,3 +19,7 @@ S3_CLIENT = boto3.client(
     aws_secret_access_key=os.environ['S3_SECRET_ACCESS_KEY'],
     config=config,
 )
+
+
+class IntegrityError(BaseException):
+    pass


### PR DESCRIPTION
* Consolidate the restore Bash script and the S3 download Python script
  to a single Python script. This facilitates logging and testing.
* Check file integrity after downloading from S3. We cannot rely on
  the 'ETag' property being the checksum, as we did in the upload
  script. boto3 downloads the file in chunks and that will cause 'ETag'
  to not match the checksum of the file. Instead, we compare the size
  of the downloaded file with the one on S3 to have some sort of
  integrity check.
* Raise a custom exception when file integrity could not be verified.
  boto3's ClientError is not a static Python exception. We shouldn't
  use it.