### PR TITLE
fix: Overwrite existing Caddy data when restoring

### DIFF
--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -87,7 +87,7 @@ def restore_caddy():
     dump_dir = CADDY_DUMPDIR
     caddy_dir = 'caddy'
     logger.info(f"Copying Caddy data from {dump_dir}")
-    shutil.copytree(dump_dir, caddy_dir)
+    shutil.copytree(dump_dir, caddy_dir, dirs_exist_ok=True)
 
     total_size = get_size(caddy_dir)
     logger.info(f"Complete. {caddy_dir} total size {total_size} bytes.")


### PR DESCRIPTION
Bu default `shutils.copytree` throws an exception if the Caddy data
directory (or any of its sub-directories) already exist.
Set `dirs_exist_ok = True` to overwrite the existing data directory.

Reference: https://docs.python.org/3.8/library/shutil.html#shutil.copytree