### PR TITLE
Fix restore integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* [fix] When checking file integrity after download, compare the checksum to 
+  the correct version of the backup file on S3.
+
 ## Version 0.0.3 (2022-04-11)
 
 * [fix] Don’t break on existing directories when restoring Caddy data.

--- a/tutorbackup/templates/backup/build/backup/backup_services.py
+++ b/tutorbackup/templates/backup/build/backup/backup_services.py
@@ -156,6 +156,7 @@ def upload_to_s3():
 
     except (ClientError, IntegrityError) as e:
         logger.exception(e, exc_info=True)
+        raise e
 
 
 @click.command()

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -154,6 +154,7 @@ def download_from_s3(version_id=None):
 
     except (ClientError, IntegrityError) as e:
         logger.exception(e, exc_info=True)
+        raise e
 
 
 @click.command()

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -124,6 +124,7 @@ def download_from_s3(version_id=None):
         obj_metadata = S3_CLIENT.head_object(
             Bucket=bucket,
             Key=os.path.basename(file_name),
+            VersionId=version_id,
         )
 
         received_version_id = obj_metadata['VersionId']


### PR DESCRIPTION
* When checking file integrity after download, compare the checksum to the correct version of the backup file on S3.
* Re-raise any exceptions that happen when interacting with S3 to stop the script at the correct place and provide better stack traces.