### PR TITLE
feat: Add timestamps to log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [fix] When checking file integrity after download, compare the checksum to 
   the correct version of the backup file on S3.
+* [feature] Add timestamps to log messages.
 
 ## Version 0.0.3 (2022-04-11)
 

--- a/tutorbackup/templates/backup/build/backup/backup_services.py
+++ b/tutorbackup/templates/backup/build/backup/backup_services.py
@@ -173,6 +173,9 @@ def main(exclude, upload):
     except KeyError:
         pass
     handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        '%(asctime)s %(levelname)s %(message)s')
+    handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(loglevel)
 

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -173,6 +173,9 @@ def main(exclude, version, download):
     except KeyError:
         pass
     handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        '%(asctime)s %(levelname)s %(message)s')
+    handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(loglevel)
 


### PR DESCRIPTION
Format log messages to include timestamp and level to improve the
readability and usefulness of the logs.