### PR TITLE
fix: Fix for k8s restore failing if no version ID is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [fix] Fix for k8s restore that would fail if no version ID was given.
+
 ## Version 0.0.4 (2022-04-12)
 
 * [fix] When checking file integrity after download, compare the checksum to 

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -121,11 +121,20 @@ def download_from_s3(version_id=None):
         )
 
         logger.info("Checking downloaded file's integrity ...")
-        obj_metadata = S3_CLIENT.head_object(
-            Bucket=bucket,
-            Key=os.path.basename(file_name),
-            VersionId=version_id,
-        )
+        # boto3.client.head_object will break if empty string or None values
+        # are passed as the VersionId argument. So add that function argument
+        # only if a version ID is given.
+        if version_id:
+            obj_metadata = S3_CLIENT.head_object(
+                Bucket=bucket,
+                Key=os.path.basename(file_name),
+                VersionId=version_id,
+            )
+        else:
+            obj_metadata = S3_CLIENT.head_object(
+                Bucket=bucket,
+                Key=os.path.basename(file_name),
+            )
 
         received_version_id = obj_metadata['VersionId']
         if version_id:


### PR DESCRIPTION
`boto3.client.head_object` will break if empty string or None values
are passed as the `VersionId` argument. So add that function argument
only if a version ID is given.