### PR TITLE
docs: Add `tutor config save` step under Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ To enable this plugin, run:
 
     tutor plugins enable backup
 
+Then, run the following command to add the plugin's configuration 
+parameters to your Tutor environment:
+
+    tutor config save
+
 Before starting Tutor, build the Docker image:
 
     tutor images build backup


### PR DESCRIPTION
Make it clear that the user needs to run `tutor config save` after
enabling the plugin. Otherwise, the build image step will fail due
to missing plugin configuration values.

This PR was prompted by [this discussion](https://discuss.overhang.io/t/introducing-the-backup-restore-plugin/2632/3) on Tutor community forum.