### PR TITLE
refactor: Use Tutor v1 plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [refactor] Use Tutor v1 plugin API
+
 ## Version 0.0.6 (2022-04-19)
 
 * [feature] List available backup versions using `tutor k8s restore 

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor<14"],
+    install_requires=["tutor <14, >=13.2.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
-        "tutor.plugin.v0": [
+        "tutor.plugin.v1": [
             "backup = tutorbackup.plugin"
         ]
     },


### PR DESCRIPTION
Tutor v1 plugin API was introduces in Tutor 13.2.0. Refactor the plugin
to use the v1 API instead of the legacy v0 API.

Reference: https://github.com/overhangio/cookiecutter-tutor-plugin#migrating-from-v0-plugins
