### PR TITLE
feat: Add ability to enable and disable CronJobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [feature] Add ability to enable and disable CronJobs by suspending them.
+
 ## Version 0.1.0 (2022-06-29)
 
 * [refactor] Use Tutor v1 plugin API

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ and Caddy untouched, run:
 By default, the backup job runs as a scheduled 
 [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
 once a day at midnight. You can change the schedule by changing the 
-`BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE` configuration parameter. To turn off 
-the scheduled job completely, set `BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE` to None. 
+`BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE` configuration parameter. To suspend 
+the scheduled backup job, set `BACKUP_K8S_CRONJOB_BACKUP_ENABLE` to `false`. 
 Note that you need to restart your Kubernetes deployment with 
 `tutor k8s quickstart` for this change to take effect.
 
@@ -117,10 +117,12 @@ for Caddy, run:
     tutor k8s restore --exclude=caddy
 
 If you want to restore your environment periodically, set the 
-`BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE` configuration parameter. This will always 
-download the latest version of the backup from the S3 bucket. Note that you 
-need to restart your Kubernetes deployment with `tutor k8s quickstart` for this 
-change to take effect.
+`BACKUP_K8S_CRONJOB_RESTORE_ENABLE` configuration parameter to `true` and provide
+the desired schedule by setting the `BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE` 
+(by default it is set to once a day at 30 mins past midnight).
+This will always download the latest version of the backup from the S3 bucket. 
+Note that you need to restart your Kubernetes deployment with `tutor k8s quickstart` 
+for these changes to take effect.
 
 You can also tweak the [history
 limits](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits)
@@ -130,12 +132,14 @@ parameters.
 Configuration
 -------------
 
-* `BACKUP_K8S_CRONJOB_HISTORYLIMIT_FAILURE` (default `1`)
-* `BACKUP_K8S_CRONJOB_HISTORYLIMIT_SUCCESS` (default `3`)
-* `BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE` (default `"0 0 * * *"`, once a day at 
-  midnight)
-* `BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE` (default `None`, periodic restore is 
-  disabled)
+* `BACKUP_K8S_CRONJOB_HISTORYLIMIT_FAILURE` (default: `1`)
+* `BACKUP_K8S_CRONJOB_HISTORYLIMIT_SUCCESS` (default: `3`)
+* `BACKUP_K8S_CRONJOB_STARTING_DEADLINE_SECONDS` (default: `900`)
+* `BACKUP_K8S_CRONJOB_BACKUP_ENABLE` (default: `true`, periodic backup is enabled.)
+* `BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE` (default: `"0 0 * * *"`, once a day at midnight)
+* `BACKUP_K8S_CRONJOB_RESTORE_ENABLE` (default: `false`, periodic restore is disabled.)
+* `BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE` (default: `"30 0 * * *"`, once a day at 30 mins past
+   midnight)
 
 The following parameters will be pre-populated if the 
 [tutor-contrib-s3](https://github.com/hastexo/tutor-contrib-s3) 

--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -64,7 +64,6 @@ spec:
           persistentVolumeClaim:
             claimName: caddy
       {% endif %}
-{% if BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE %}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -74,7 +73,9 @@ metadata:
     app.kubernetes.io/component: cronjob
 spec:
   failedJobsHistoryLimit: {{ BACKUP_K8S_CRONJOB_HISTORYLIMIT_FAILURE }}
+  suspend: {% if BACKUP_K8S_CRONJOB_BACKUP_ENABLE %}false{% else %}true{% endif %}
   schedule: '{{ BACKUP_K8S_CRONJOB_BACKUP_SCHEDULE }}'
+  startingDeadlineSeconds: {{ BACKUP_K8S_CRONJOB_STARTING_DEADLINE_SECONDS }}
   successfulJobsHistoryLimit: {{ BACKUP_K8S_CRONJOB_HISTORYLIMIT_SUCCESS }}
   jobTemplate:
     spec:
@@ -138,8 +139,6 @@ spec:
               persistentVolumeClaim:
                 claimName: caddy
           {% endif %}
-{% endif %}
-{% if BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE %}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -149,7 +148,9 @@ metadata:
     app.kubernetes.io/component: cronjob
 spec:
   failedJobsHistoryLimit: {{ BACKUP_K8S_CRONJOB_HISTORYLIMIT_FAILURE }}
+  suspend: {% if BACKUP_K8S_CRONJOB_RESTORE_ENABLE %}false{% else %}true{% endif %}
   schedule: '{{ BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE }}'
+  startingDeadlineSeconds: {{ BACKUP_K8S_CRONJOB_STARTING_DEADLINE_SECONDS }}
   successfulJobsHistoryLimit: {{ BACKUP_K8S_CRONJOB_HISTORYLIMIT_SUCCESS }}
   jobTemplate:
     spec:
@@ -213,4 +214,3 @@ spec:
               persistentVolumeClaim:
                 claimName: caddy
           {% endif %}
-{% endif %}

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -15,8 +15,11 @@ config = {
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}backup:{{ BACKUP_VERSION }}",  # noqa: E501
         "K8S_CRONJOB_HISTORYLIMIT_FAILURE": 1,
         "K8S_CRONJOB_HISTORYLIMIT_SUCCESS": 3,
+        "K8S_CRONJOB_STARTING_DEADLINE_SECONDS": 900,
+        "K8S_CRONJOB_BACKUP_ENABLE": True,
         "K8S_CRONJOB_BACKUP_SCHEDULE": "0 0 * * *",
-        "K8S_CRONJOB_RESTORE_SCHEDULE": None,
+        "K8S_CRONJOB_RESTORE_ENABLE": False,
+        "K8S_CRONJOB_RESTORE_SCHEDULE": "30 0 * * *",
         "S3_HOST": "{{ S3_HOST | default('') }}",
         "S3_PORT": "{{ S3_PORT | default('') }}",
         "S3_REGION_NAME": "{{ S3_REGION | default('') }}",


### PR DESCRIPTION
Previously we relied on the existence of the schedule configuration
parameters to add or remove the corresponding backup and restore
CronJob. But, if a CronJob is already defined, removing its manifest
does not deactivate it. To deactivate a CronJob we need to suspend it.

Add `BACKUP_K8S_CRONJOB_BACKUP_ENABLE` and
`BACKUP_K8S_CRONJOB_RESTORE_ENABLE` to set the `.spec.suspend` in the
CronJob manifest. We also need to set `.spec.startingDeadlineSeconds`
to prevent the missed jobs to be immediately scheduled when
`.spec.suspend` is toggled from `true` to `false`.

Reference:
https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/