### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 0.1.0
+current_version = 0.2.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 0.2.0 (2022-07-26)
 
 * [feature] Add ability to enable and disable CronJobs by suspending them.
 * [fix] Remove dependencies on mysql and mongodb from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 * [feature] Add ability to enable and disable CronJobs by suspending them.
+* [fix] Remove dependencies on mysql and mongodb from the
+  docker-compose configuration if Tutor is configured to run with
+  external MySQL and MongoDB.
 
 ## Version 0.1.0 (2022-06-29)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ appropriate one:
 | Open edX release | Tutor version     | Plugin branch | Plugin release |
 |------------------|-------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
-| Maple            | `>=13.2, <14`[^1] | `main`        | 0.1.0          |
+| Maple            | `>=13.2, <14`[^1] | `main`        | 0.2.0          |
 | Nutmeg           | `>=14.0, <15`     | forthcoming   | forthcoming    |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
@@ -42,7 +42,7 @@ appropriate one:
 
 ## Installation
 
-    pip install git+https://github.com/hastexo/tutor-contrib-backup@v0.1.0
+    pip install git+https://github.com/hastexo/tutor-contrib-backup@v0.2.0
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ periodically download the latest backup and restore your environment. This
 can, for example, be useful if you want to maintain a standby site for 
 disaster recovery purposes.
 
+## Version compatibility matrix
+
+You must install a supported release of this plugin to match the Open
+edX and Tutor version you are deploying. If you are installing this
+plugin from a branch in this Git repository, you must select the
+appropriate one:
+
+| Open edX release | Tutor version     | Plugin branch | Plugin release |
+|------------------|-------------------|---------------|----------------|
+| Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
+| Maple            | `>=13.2, <14`[^1] | `main`        | 0.1.0          |
+| Nutmeg           | `>=14.0, <15`     | forthcoming   | forthcoming    |
+
+[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
+    later. That is because this plugin uses the Tutor v1 plugin API,
+    [which was introduced with that
+    release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
+
 ## Installation
 
     pip install git+https://github.com/hastexo/tutor-contrib-backup@v0.1.0


### PR DESCRIPTION
#33 adds a new feature, so we want to bump the minor.
Also, add a changelog entry for #31, and a doc patch to address #32. 