### PR TITLE
feat: Add a date stamp to backup file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Unreleased
+
+* [feature] From this version forward the backup files contain a date
+  stamp, and are thus named `backup.YYYY-MM-DD.tar.xz` rather than
+  just `backup.tar.xz`. Users can now specify a date when using the
+  restore command. In a Kubernetes deployment, if multiple backups are
+  made in one day, users can specify the date and the version ID of
+  the desired backup when restoring. If no date is specified on
+  restore, the restore job looks for a backup from today. This means
+  that when upgrading from an earlier version, attempting a restore
+  operation *before any new backup is made* will fail because the
+  restore will be looking for a backup named
+  `backup.YYYY-MM-DD.tar.xz` when no such backup exists yet. In that
+  event, please rename your existing `backup.tar.xz` file to the
+  `backup.YYYY-MM-DD.tar.xz` format, reflecting the current date.
+
 ## Version 0.2.0 (2022-07-26)
 
 * [feature] Add ability to enable and disable CronJobs by suspending them.

--- a/README.md
+++ b/README.md
@@ -101,10 +101,14 @@ If you need to run the backup job outside the schedule, use:
 The backup job backs up MySQL, MongoDB, and the Caddy data directory, 
 creates a tar file with a date stamp, and uploads it to an S3 storage bucket as 
 set by the `BACKUP_S3_*` configuration parameters. Note that if you want to 
-run multiple backups in a day, you might need to enable
+run multiple backups in a day, you might want to enable
 [object versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html)
  in your bucket. Otherwise, only the last backup taken on any day survives.
 
+You might also consider applying a lifecyle [expiration
+rule](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-general-considerations.html)
+to your storage bucket if you want to retain your backups for a
+limited time, and discard backups beyond a certain age.
 
 To restore from the latest version of the backup made today:
 

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from .__about__ import __version__
 from glob import glob
 import os
@@ -72,16 +73,12 @@ def backup(context):
     multiple=True,
     help="Exclude services from restore"
 )
-def restore(context, exclude):
+@click.option('--date', type=click.DateTime(formats=["%Y-%m-%d"]),
+              default=str(datetime.today().date()),
+              help="Backup date (YYYY-MM-DD)")
+def restore(context, exclude, date):
     config = tutor_config.load(context.root)
-
-    filename = context.root + "/env/backup/backup.tar.xz"
-    click.echo(f"Restoring from '{filename}'")
-    if not os.path.isfile(filename):
-        click.echo(f"ERROR: '{filename}' not found!")
-        return
-
-    command = "python restore_services.py"
+    command = f"python restore_services.py --date={date.date()}"
     if 'caddy' not in exclude:
         web_proxy_enabled = config["ENABLE_WEB_PROXY"]
         https_enabled = config["ENABLE_HTTPS"]
@@ -112,6 +109,9 @@ def backup(context):  # noqa: F811
 
 @k8s_command_group.command(help="restore MySQL, MongoDB, and Caddy")
 @click.pass_obj
+@click.option('--date', type=click.DateTime(formats=["%Y-%m-%d"]),
+              default=str(datetime.today().date()),
+              help="Backup date (YYYY-MM-DD)")
 @click.option('--version', default="", type=str,
               help="Version ID of the backup file")
 @click.option(
@@ -122,10 +122,10 @@ def backup(context):  # noqa: F811
 )
 @click.option('--list-versions', is_flag=False, flag_value=20, type=int,
               help="List n latest backup versions (n=20 by default)")
-def restore(context, version, exclude, list_versions):  # noqa: F811
+def restore(context, date, version, exclude, list_versions):  # noqa: F811
     config = tutor_config.load(context.root)
 
-    command = "python restore_services.py"
+    command = f"python restore_services.py --date={date.date()}"
     if list_versions:
         command += f" --list-versions={list_versions}"
     else:

--- a/tutorbackup/templates/backup/build/backup/backup_services.py
+++ b/tutorbackup/templates/backup/build/backup/backup_services.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import sys
 import tarfile
+from datetime import datetime
 from subprocess import check_call
 
 import click
@@ -20,7 +21,8 @@ MYSQL_DUMPFILE = os.path.join(DUMP_DIRECTORY, 'mysql_dump.sql')
 MONGODB_DUMPDIR = os.path.join(DUMP_DIRECTORY, 'mongodb_dump')
 CADDY_DUMPDIR = os.path.join(DUMP_DIRECTORY, 'caddy')
 
-TARFILE = '/backup/backup.tar.xz'
+date_stamp = datetime.today().strftime("%Y-%m-%d")
+TARFILE = f'/backup/backup.{date_stamp}.tar.xz'
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Users can now specify a date when using the restore command. In a
Kubernetes deployment, if multiple backups are made in one day, users
can specify the date and the version ID of the desired backup when
restoring.