### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 0.2.0
+current_version = 0.3.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 0.3.0 (2022-07-28)
 
 * [feature] From this version forward the backup files contain a date
   stamp, and are thus named `backup.YYYY-MM-DD.tar.xz` rather than

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ service, some of these values may be required to set.
   [rgw_dns_name](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
   you will need `BACKUP_S3_ADDRESSING_STYLE: path`.
 
+## Changelog
+
+For a detailed breakdown of features and fixes in each release, please
+see the [changelog](CHANGELOG.md).
+
 ## License
 
 This software is licensed under the terms of the AGPLv3.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ appropriate one:
 | Open edX release | Tutor version     | Plugin branch | Plugin release |
 |------------------|-------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
-| Maple            | `>=13.2, <14`[^1] | `main`        | 0.2.0          |
+| Maple            | `>=13.2, <14`[^1] | `main`        | 0.3.0          |
 | Nutmeg           | `>=14.0, <15`     | forthcoming   | forthcoming    |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
@@ -43,7 +43,7 @@ appropriate one:
 
 ## Installation
 
-    pip install git+https://github.com/hastexo/tutor-contrib-backup@v0.2.0
+    pip install git+https://github.com/hastexo/tutor-contrib-backup@v0.3.0
 
 ## Usage
 


### PR DESCRIPTION
Since we are adding a new feature (date-stamped backups) from #35, bump the minor.
Also include a small update to the README that explicitly references the changelog.