### PR TITLE
feat: Support Tutor 14 and Open edX Nutmeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
+  a configuration format change from JSON to YAML, meaning that from
+  version 1.0.0 this plugin only supports Tutor versions from 14.0.0
+  (and with that, only Open edX versions from Nutmeg).
+
 ## Version 0.3.0 (2022-07-28)
 
 * [feature] From this version forward the backup files contain a date

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ appropriate one:
 | Open edX release | Tutor version     | Plugin branch | Plugin release |
 |------------------|-------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
-| Maple            | `>=13.2, <14`[^1] | `main`        | 0.3.0          |
-| Nutmeg           | `>=14.0, <15`     | forthcoming   | forthcoming    |
+| Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x          |
+| Nutmeg           | `>=14.0, <15`     | `main`        | 1.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <14, >=13.2.0"],
+    install_requires=["tutor <15, >=14.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
In version 14, Tutor's configuration file format changes from JSON (`lms.env.json`, `cms.env.json`) to YAML (`lms.yml`, `cms.yml`).
This plugin currently does not use any of those configuration files. But we want to bump the minimal Tutor version requirements to 14 to stay current with Tutor. Any new Tutor configuration files created should now be YAML.

The plugin supports Open edX Nutmeg as of this PR.

Update version compatibility matrix and add information about the supported Open edX releases in `maple` and `main` plugin branches and the corresponding releases.