### PR TITLE
build: Version 1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 0.3.0
+current_version = 1.0.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 1.0.0 (2022-08-04)
 
 * [BREAKING CHANGE] Support Tutor 14 and Open edX Nutmeg. This entails
   a configuration format change from JSON to YAML, meaning that from

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ appropriate one:
 
 ## Installation
 
-    pip install git+https://github.com/hastexo/tutor-contrib-backup@v0.3.0
+    pip install git+https://github.com/hastexo/tutor-contrib-backup@v1.0.0
 
 ## Usage
 


### PR DESCRIPTION
As of this release, the plugin supports Tutor v14 and hence Open edX Nutmeg.