### PR TITLE
docs: Small README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Backup plugin for Tutor
 
-This is an **experimental** plugin for
-[Tutor](https://docs.tutor.overhang.io) that provides backup and restore 
-functionality for MySQL, MongoDB, and Caddy services in both local and 
-Kubernetes Tutor deployments.
+This is a plugin for [Tutor](https://docs.tutor.overhang.io) that
+provides backup and restore functionality for MySQL, MongoDB, and
+Caddy services in both local and Kubernetes Tutor deployments.
 
 In a local deployment, you can run the backup from the command line.
 The backups are stored as a single compressed tar file, named

--- a/README.md
+++ b/README.md
@@ -215,20 +215,31 @@ service, some of these values may be required to set.
 
 ### Selecting the MySQL databases to backup
 
-By default, all databases will be included in the backup. This is the desired behavior 
-in most of the cases.  
-However, in some situations it may be necessary to choose explicitly which databases must 
-be included in the list. For example, when the same MySQL cluster is used for other purposes 
-and holds logical databases for other services, you might not want to backup them also.
-If you are using a cloud provider database as a service, the cluster may include internal databases 
-that the LMS user might not be allowed to access, therefore throwing an error during the backup process.
-Currently there is a 
-[know limitation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql_rds_import_binlog_ssl_material.html) 
-of AWS Aurora service that will break the backup process and throw an error like this:
-`mysqldump: Couldn't execute 'SHOW CREATE PROCEDURE rds_import_binlog_ssl_material': Failed to load routine mysql.rds_import_binlog_ssl_material. The table mysql.proc is missing, corrupt, or contains bad data`
+By default, all MySQL databases will be included in the backup. This is the
+desired behavior in most cases.
 
-For these cases, you can limit the MySQL databases to backup using the `BACKUP_MYSQL_DATABASES` setting.
-This setting takes a list of strings with the names of the databases. E.g.:
+However, in some situations it may be necessary to explicitly choose
+which databases must be included in the backup. For example, when the
+same MySQL cluster is used for other purposes and holds logical
+databases for other services, you might not want to backup all
+databases. In addition, if you are using a cloud provider database as
+a service, the cluster may include internal databases that the LMS
+user might not be allowed to access, thus throwing an error
+during the backup process.[^aurora]
+
+[^aurora]: There is a known limitation in [certain configurations of
+  AWS
+  Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql_rds_import_binlog_ssl_material.html)
+  in which an attempt to back up the internal `mysql` database will
+  result in an error: `mysqldump: Couldn't execute 'SHOW CREATE
+  PROCEDURE rds_import_binlog_ssl_material': Failed to load routine
+  mysql.rds_import_binlog_ssl_material. The table mysql.proc is
+  missing, corrupt, or contains bad data.`
+
+In such cases, you can limit the MySQL databases to backup using the
+`BACKUP_MYSQL_DATABASES` setting.  This setting takes a list of
+strings with the names of the databases, such as:
+
 ```yaml
 BACKUP_MYSQL_DATABASES:
   - edxapp
@@ -236,8 +247,10 @@ BACKUP_MYSQL_DATABASES:
   - ecommerce
   - discovery
 ```
-Remember to include all databases used by the edx-platform, as well as those created
-by the plugins installed.
+
+Remember to include all databases used by
+[edx-platform](https://github.com/openedx/edx-platform), as well as
+those created by any plugins installed.
 
 ## Changelog
 


### PR DESCRIPTION
* Reformat the section on using `BACKUP_MYSQL_DATABASES` to include only certain databases in the backup. Move the inline note on AWS Aurora to a footnote.
* Remove the "experimental" warning from the README.
