### PR TITLE
fix: Use ephemeral volumes in K8s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MongoDB databases to back up.
 Add `BACKUP_MONGODB_AUTHENTICATION_DATABASE` to override default 
 authentication database name.
 * [refactor] Remove obsolete scripts.
+* [fix] Use ephemeral volumes in K8s for data volume
 
 ## Version 1.1.0 (2022-08-31)
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ rule](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-expire-gen
 to your storage bucket if you want to retain your backups for a
 limited time, and discard backups beyond a certain age.
 
+If you are running Kubernetes in a production environment, you might need to store the 
+dump and tar files in a [generic ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes) instead of the default local node storage
+(requires Kubernetes 1.23 or higher). To accomplish this, set `BACKUP_K8S_USE_EPHEMERAL_VOLUMES` to `True`.
+Optionally you can change the volume size using the `BACKUP_K8S_EPHEMERAL_VOLUME_SIZE`
+variable, which is `10Gi` by default.
+
+
 To restore from the latest version of the backup made today:
 
     tutor k8s restore
@@ -179,6 +186,8 @@ Configuration
 * `BACKUP_K8S_CRONJOB_RESTORE_ENABLE` (default: `false`, periodic restore is disabled.)
 * `BACKUP_K8S_CRONJOB_RESTORE_SCHEDULE` (default: `"30 0 * * *"`, once a day at 30 mins past
    midnight)
+* `BACKUP_K8S_USE_EPHEMERAL_VOLUMES` (default: `false`)
+* `BACKUP_K8S_EPHEMERAL_VOLUME_SIZE` (default: `10Gi`)
 
 Make sure the periodic backup job always runs before the restore job during the 
 day.

--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -65,15 +65,37 @@ spec:
               value: '{{ BACKUP_S3_SECRET_ACCESS_KEY }}'
             - name: S3_BUCKET_NAME
               value: '{{ BACKUP_S3_BUCKET_NAME }}'
-      {% if ENABLE_WEB_PROXY %}
+          {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES or ENABLE_WEB_PROXY %}
           volumeMounts:
+            {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
+            - mountPath: /data/
+              name: backup-volume
+            {% endif %}
+            {% if ENABLE_WEB_PROXY %}
             - mountPath: /caddy/
               name: data
+            {% endif %}
+          {% endif %}
+      {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES or ENABLE_WEB_PROXY %}
       volumes:
+        {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
+        - name: backup-volume
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: {{ BACKUP_K8S_EPHEMERAL_VOLUME_SIZE }}
+        {% endif %}
+        {% if ENABLE_WEB_PROXY %}
         - name: data
           persistentVolumeClaim:
             claimName: caddy
+        {% endif %}
       {% endif %}
+
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -150,14 +172,35 @@ spec:
                   value: '{{ BACKUP_S3_BUCKET_NAME }}'
               command: ["/bin/sh", "-c"]
               args: ["python backup_services.py --upload{% if not ENABLE_WEB_PROXY %} --exclude=caddy{% endif %}"]
-          {% if ENABLE_WEB_PROXY %}
+              {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES or ENABLE_WEB_PROXY %}
               volumeMounts:
+                {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
+                - mountPath: /data/
+                  name: backup-volume
+                {% endif %}
+                {% if ENABLE_WEB_PROXY %}
                 - mountPath: /caddy/
                   name: data
+                {% endif %}
+              {% endif %}
+          {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES or ENABLE_WEB_PROXY %}
           volumes:
+            {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
+            - name: backup-volume
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes:
+                      - ReadWriteOnce
+                    resources:
+                      requests:
+                        storage: {{ BACKUP_K8S_EPHEMERAL_VOLUME_SIZE }}
+            {% endif %}
+            {% if ENABLE_WEB_PROXY %}
             - name: data
               persistentVolumeClaim:
                 claimName: caddy
+            {% endif %}
           {% endif %}
 ---
 apiVersion: batch/v1
@@ -235,12 +278,33 @@ spec:
                   value: '{{ BACKUP_S3_BUCKET_NAME }}'
               command: ["/bin/sh", "-c"]
               args: ["python restore_services.py --download{% if not ENABLE_WEB_PROXY %} --exclude=caddy{% endif %}"]
-          {% if ENABLE_WEB_PROXY %}
+              {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES or ENABLE_WEB_PROXY %}
               volumeMounts:
+                {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
+                - mountPath: /data/
+                  name: backup-volume
+                {% endif %}
+                {% if ENABLE_WEB_PROXY %}
                 - mountPath: /caddy/
                   name: data
+                {% endif %}
+              {% endif %}
+          {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES or ENABLE_WEB_PROXY %}
           volumes:
+            {% if BACKUP_K8S_USE_EPHEMERAL_VOLUMES %}
+            - name: backup-volume
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes:
+                      - ReadWriteOnce
+                    resources:
+                      requests:
+                        storage: {{ BACKUP_K8S_EPHEMERAL_VOLUME_SIZE }}
+            {% endif %}
+            {% if ENABLE_WEB_PROXY %}
             - name: data
               persistentVolumeClaim:
                 claimName: caddy
+            {% endif %}
           {% endif %}

--- a/tutorbackup/patches/local-docker-compose-jobs-services
+++ b/tutorbackup/patches/local-docker-compose-jobs-services
@@ -20,7 +20,7 @@ backup-job:
     {% endif %}
     - MONGODB_AUTHENTICATION_DATABASE={{ BACKUP_MONGODB_AUTHENTICATION_DATABASE }}
   volumes:
-    - ../backup:/backup
+    - ../backup:/data/backup
     {% if ENABLE_HTTPS and ENABLE_WEB_PROXY %}- ../../data/caddy:/caddy{% endif %}
   depends_on:
     {% if RUN_MYSQL %}- mysql{% endif %}

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -21,6 +21,8 @@ config = {
         "K8S_CRONJOB_BACKUP_SCHEDULE": "0 0 * * *",
         "K8S_CRONJOB_RESTORE_ENABLE": False,
         "K8S_CRONJOB_RESTORE_SCHEDULE": "30 0 * * *",
+        "K8S_USE_EPHEMERAL_VOLUMES": False,
+        "K8S_EPHEMERAL_VOLUME_SIZE": "10Gi",
         "S3_HOST": "{{ S3_HOST | default('') }}",
         "S3_PORT": "{{ S3_PORT | default('') }}",
         "S3_REGION_NAME": "{{ S3_REGION | default('') }}",

--- a/tutorbackup/templates/backup/build/backup/backup_services.py
+++ b/tutorbackup/templates/backup/build/backup/backup_services.py
@@ -8,6 +8,7 @@ import sys
 import tarfile
 from datetime import datetime
 from subprocess import check_call
+from pathlib import Path
 
 import click
 from botocore.exceptions import ClientError
@@ -22,7 +23,7 @@ MONGODB_DUMPDIR = os.path.join(DUMP_DIRECTORY, 'mongodb_dump')
 CADDY_DUMPDIR = os.path.join(DUMP_DIRECTORY, 'caddy')
 
 date_stamp = datetime.today().strftime("%Y-%m-%d")
-TARFILE = f'/backup/backup.{date_stamp}.tar.xz'
+TARFILE = f'/data/backup/backup.{date_stamp}.tar.xz'
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,11 @@ def caddydump():
 
 def archive(paths):
     outfile = TARFILE
+
+    # Create the subdirectories to the tar file
+    outfile_path = os.path.dirname(outfile)
+    if outfile_path:
+        Path(outfile_path).mkdir(parents=True, exist_ok=True)
 
     logger.info(f"Creating archive {outfile}")
     with tarfile.open(outfile, "w:xz") as tar:

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tarfile
 from datetime import datetime
+from pathlib import Path
 from subprocess import check_call
 
 import click
@@ -109,6 +110,11 @@ def extract(file_name):
 
 def download_from_s3(file_name, version_id=None):
     from s3_client import S3_CLIENT, IntegrityError
+
+    # Create the subdirectories to the tar file
+    outfile_path = os.path.dirname(file_name)
+    if outfile_path:
+        Path(outfile_path).mkdir(parents=True, exist_ok=True)
 
     bucket = ENV['S3_BUCKET_NAME']
 
@@ -220,7 +226,7 @@ def main(exclude, date, version, download, list_versions):
     logger.addHandler(handler)
     logger.setLevel(loglevel)
 
-    file_name = f'/backup/backup.{date.date()}.tar.xz'
+    file_name = f'/data/backup/backup.{date.date()}.tar.xz'
 
     if list_versions:
         get_versions(file_name, number_of_versions=list_versions)


### PR DESCRIPTION
In K8s use ephemeral volumes for data and backup mount points.