### PR TITLE
feat: Add ability to select MongoDB databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+* [feature] Add the `BACKUP_MONGODB_DATABASES` setting to select the 
+MongoDB databases to back up. 
+Add `BACKUP_MONGODB_AUTHENTICATION_DATABASE` to override default 
+authentication database name.
 * [refactor] Remove obsolete scripts.
 
 ## Version 1.1.0 (2022-08-31)

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ service, some of these values may be required to set.
   [rgw_dns_name](https://docs.ceph.com/en/latest/radosgw/config-ref/#confval-rgw_dns_name),
   you will need `BACKUP_S3_ADDRESSING_STYLE: path`.
 
-### Selecting the MySQL databases to backup
+### Selecting databases to backup
 
-By default, all MySQL databases will be included in the backup. This is the
-desired behavior in most cases.
+By default, all MySQL and MongoDB databases will be included in the 
+backup. This is the desired behavior in most cases.
 
 However, in some situations it may be necessary to explicitly choose
 which databases must be included in the backup. For example, when the
-same MySQL cluster is used for other purposes and holds logical
+same database cluster is used for other purposes and holds logical
 databases for other services, you might not want to backup all
 databases. In addition, if you are using a cloud provider database as
 a service, the cluster may include internal databases that the LMS
@@ -236,9 +236,10 @@ during the backup process.[^aurora]
   mysql.rds_import_binlog_ssl_material. The table mysql.proc is
   missing, corrupt, or contains bad data.`
 
-In such cases, you can limit the MySQL databases to backup using the
-`BACKUP_MYSQL_DATABASES` setting.  This setting takes a list of
-strings with the names of the databases, such as:
+In such cases, you can specify the MySQL and MongoDB databases you would like
+to back up, using the `BACKUP_MYSQL_DATABASES` and `BACKUP_MONGODB_DATABASES` 
+settings. These settings take a list of strings with the names of the 
+databases, such as:
 
 ```yaml
 BACKUP_MYSQL_DATABASES:
@@ -248,9 +249,19 @@ BACKUP_MYSQL_DATABASES:
   - discovery
 ```
 
+```yaml
+BACKUP_MONGODB_DATABASES:
+  - openedx
+  - cs_comments_service
+```
+
 Remember to include all databases used by
 [edx-platform](https://github.com/openedx/edx-platform), as well as
 those created by any plugins installed.
+
+If your MongoDB instance uses an authentication database name other 
+than `admin`, make sure you provide that with
+`BACKUP_MONGODB_AUTHENTICATION_DATABASE`.
 
 ## Changelog
 

--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -43,6 +43,12 @@ spec:
               value: '{{ MONGODB_USERNAME }}'
             - name: MONGODB_PASSWORD
               value: '{{ MONGODB_PASSWORD }}'{% endif %}
+            {% if BACKUP_MONGODB_DATABASES %}
+            - name: MONGODB_DATABASES
+              value: {{ BACKUP_MONGODB_DATABASES | join(" ") }}
+            {% endif %}
+            - name: MONGODB_AUTHENTICATION_DATABASE
+              value: '{{ BACKUP_MONGODB_AUTHENTICATION_DATABASE }}'
             - name: S3_SIGNATURE_VERSION
               value: '{{ BACKUP_S3_SIGNATURE_VERSION }}'
             - name: S3_ADDRESSING_STYLE
@@ -120,6 +126,12 @@ spec:
                   value: '{{ MONGODB_USERNAME }}'
                 - name: MONGODB_PASSWORD
                   value: '{{ MONGODB_PASSWORD }}'{% endif %}
+                {% if BACKUP_MONGODB_DATABASES %}
+                - name: MONGODB_DATABASES
+                  value: {{ BACKUP_MONGODB_DATABASES | join(" ") }}
+                {% endif %}
+                - name: MONGODB_AUTHENTICATION_DATABASE
+                  value: '{{ BACKUP_MONGODB_AUTHENTICATION_DATABASE }}'
                 - name: S3_SIGNATURE_VERSION
                   value: '{{ BACKUP_S3_SIGNATURE_VERSION }}'
                 - name: S3_ADDRESSING_STYLE
@@ -199,6 +211,12 @@ spec:
                   value: '{{ MONGODB_USERNAME }}'
                 - name: MONGODB_PASSWORD
                   value: '{{ MONGODB_PASSWORD }}'{% endif %}
+                {% if BACKUP_MONGODB_DATABASES %}
+                - name: MONGODB_DATABASES
+                  value: {{ BACKUP_MONGODB_DATABASES | join(" ") }}
+                {% endif %}
+                - name: MONGODB_AUTHENTICATION_DATABASE
+                  value: '{{ BACKUP_MONGODB_AUTHENTICATION_DATABASE }}'
                 - name: S3_SIGNATURE_VERSION
                   value: '{{ BACKUP_S3_SIGNATURE_VERSION }}'
                 - name: S3_ADDRESSING_STYLE

--- a/tutorbackup/patches/local-docker-compose-jobs-services
+++ b/tutorbackup/patches/local-docker-compose-jobs-services
@@ -11,11 +11,14 @@ backup-job:
     {% if BACKUP_MYSQL_DATABASES %}
     - MYSQL_DATABASES={{ BACKUP_MYSQL_DATABASES | join(" ") }}
     {% endif %}
-
+    {% if BACKUP_MONGODB_DATABASES %}
+    - MONGODB_DATABASES={{ BACKUP_MONGODB_DATABASES | join(" ") }}
+    {% endif %}
     {% if MONGODB_USERNAME and MONGODB_PASSWORD %}
     - MONGODB_USERNAME={{ MONGODB_USERNAME }}
     - MONGODB_PASSWORD={{ MONGODB_PASSWORD }}
     {% endif %}
+    - MONGODB_AUTHENTICATION_DATABASE={{ BACKUP_MONGODB_AUTHENTICATION_DATABASE }}
   volumes:
     - ../backup:/backup
     {% if ENABLE_HTTPS and ENABLE_WEB_PROXY %}- ../../data/caddy:/caddy{% endif %}

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -31,6 +31,8 @@ config = {
         "S3_SECRET_ACCESS_KEY": "{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}",
         "S3_BUCKET_NAME": "backups",
         "MYSQL_DATABASES": [],
+        "MONGODB_DATABASES": [],
+        "MONGODB_AUTHENTICATION_DATABASE": "admin",
     }
 }
 


### PR DESCRIPTION
Add the `BACKUP_MONGODB_DATABASES` setting to select the
MongoDB databases to back up. If this setting is not provided,
back up all databases.

Since we are providing the `--db` flag to `mongodump`, when backing
up specific databases, we need to also provide the authentication
database. Otherwise `mongodump` uses whatever database is set by `--db`
to authenticate. To give users the ability to specify the
authentication database, add `BACKUP_MONGODB_AUTHENTICATION_DATABASE`
which defaults to `admin`.

Fixes #46.