### PR TITLE
fix: Make checksum calculation memory-efficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add `BACKUP_MONGODB_AUTHENTICATION_DATABASE` to override default
 authentication database name.
 * [refactor] Remove obsolete scripts.
 * [fix] Use ephemeral volumes in K8s for data volume
+* [fix] When calculating the checksum for large backup tar files, all the file
+was read into memory. This could cause pods to be killed when backing
+up large databases. Fix that by reading in the tar file in chunks when
+calculating the checksum.
 
 ## Version 1.1.0 (2022-08-31)
 

--- a/tutorbackup/templates/backup/build/backup/backup_services.py
+++ b/tutorbackup/templates/backup/build/backup/backup_services.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import hashlib
 import logging
 import os
 import shutil
@@ -152,15 +151,14 @@ def archive(paths):
 
 
 def upload_to_s3():
-    from s3_client import S3_CLIENT, IntegrityError
+    from s3_client import S3_CLIENT, IntegrityError, calculate_checksum
 
     bucket = ENV['S3_BUCKET_NAME']
     file_name = TARFILE
 
+    logger.info(f"Calculating checksum for {file_name}")
+    calculated_checksum = calculate_checksum(file_name)
     logger.info(f"Uploading {file_name} to S3 bucket {bucket}")
-    calculated_checksum = hashlib.md5(
-        open(file_name, 'rb').read()).hexdigest()
-
     try:
         S3_CLIENT.upload_file(
             file_name,

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import hashlib
 import logging
 import os
 import shutil
@@ -109,7 +108,7 @@ def extract(file_name):
 
 
 def download_from_s3(file_name, version_id=None):
-    from s3_client import S3_CLIENT, IntegrityError
+    from s3_client import S3_CLIENT, IntegrityError, calculate_checksum
 
     # Create the subdirectories to the tar file
     outfile_path = os.path.dirname(file_name)
@@ -150,8 +149,7 @@ def download_from_s3(file_name, version_id=None):
             version_id_correct = True
 
         received_checksum = obj_metadata['Metadata']['checksum-md5']
-        calculated_checksum = hashlib.md5(
-            open(file_name, 'rb').read()).hexdigest()
+        calculated_checksum = calculate_checksum(file_name)
         checksum_correct = (received_checksum == calculated_checksum)
 
         size = os.path.getsize(file_name)

--- a/tutorbackup/templates/backup/build/backup/s3_client.py
+++ b/tutorbackup/templates/backup/build/backup/s3_client.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import boto3
 from botocore.config import Config
@@ -23,3 +24,19 @@ S3_CLIENT = boto3.client(
 
 class IntegrityError(BaseException):
     pass
+
+
+def calculate_checksum(file_name):
+    # To avoid reading in the whole file into memory, break it
+    # down into chunks and calculate the checksum by updating
+    # the md5 hash. The number of read bytes should be a
+    # multiple of the hash algorithm's block size. Here we have
+    # chosen 128 times MD5's block size (128). This results in
+    # chunks of 16KiB. Values above this do not show a tangible
+    # performance benefit.
+    num_of_blocks = 128
+    with open(file_name, "rb") as f:
+        file_hash = hashlib.md5()
+        while chunk := f.read(num_of_blocks * file_hash.block_size):
+            file_hash.update(chunk)
+    return file_hash.hexdigest()


### PR DESCRIPTION
When calculating the checksum for large backup tar files, all the file was read into memory. This could cause pods to be killed when backing up large databases. Fix that by reading in the tar file in chunks when calculating the checksum.