### PR TITLE
Update GitHub Actions, switch gitlint to regex "search" semantics

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,9 +16,13 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
+      with:
+        # Checkout a pull request's HEAD commit instead of the merge
+        # commit, so that gitlint lints the correct commit message.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitlint
+++ b/.gitlint
@@ -1,5 +1,6 @@
 [general]
 contrib=contrib-title-conventional-commits
+regex-style-search=true
 
 # When invoked as just "gitlint" without any other arguments, Gitlint
 # processes the most recent commit message *unless* it's being fed


### PR DESCRIPTION
* Fix the GitHub Actions workflow so that it uses the latest releases and
  lints the correct commit's commit message.
* Explicitly switch gitlint to regex "search" semantics
