### PR TITLE
fix: Set MONGORESTORE_ADDITIONAL_OPTIONS on cron job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* [fix] Add the `BACKUP_MONGORESTORE_ADDITIONAL_OPTIONS` setting to
+  the definition of the Kubernetes restore cron job (in addition to
+  that of the ad-hoc Kubernetes job).
+
 ## Version 2.0.0 (2023-03-15)
 
 * [BREAKING CHANGE] Add support for Tutor 15 and Open edX Olive.

--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -262,6 +262,8 @@ spec:
                 {% endif %}
                 - name: MONGODB_AUTHENTICATION_DATABASE
                   value: '{{ BACKUP_MONGODB_AUTHENTICATION_DATABASE }}'
+                - name: MONGORESTORE_ADDITIONAL_OPTIONS
+                  value: '{{ BACKUP_MONGORESTORE_ADDITIONAL_OPTIONS }}'
                 - name: S3_SIGNATURE_VERSION
                   value: '{{ BACKUP_S3_SIGNATURE_VERSION }}'
                 - name: S3_ADDRESSING_STYLE


### PR DESCRIPTION
Commit 404068260ad709dadadf4d9477ec49fb1bfb8786 introduced `BACKUP_MONGORESTORE_ADDITIONAL_OPTIONS`, but only added it to the Kubernetes environment for the ad-hoc restore job. It failed to also set it for the corresponding cron job definition.

Add this environment variable to the definition of the cron job, as well.

Reference:
https://github.com/hastexo/tutor-contrib-backup/pull/55