### PR TITLE
Update Dockerfile: use Ubuntu Focal as the base image, install MySQL 8 and MongoDB 4.4 clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* [fix]: Switch the MySQL client tools to version 8.0 and the MongoDB
+  client tools to version 4.4.
+
+This version drops compatibility with Open edX Olive and Tutor 15.
+
 ## Version 2.1.1 (2023-10-12)
 
 * [fix] Avoid running Kubernetes CronJob instances concurrently by

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ appropriate one:
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.3.x          |
 | Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.x.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 2.x.x          |
-| Palm             | `>=16.0, <17`     | `main`        | 2.x.x          |
+| Palm             | `>=16.0, <17`     | `main`        | 3.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <17, >=15.0.0"],
+    install_requires=["tutor <17, >=16.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [

--- a/tutorbackup/templates/backup/build/backup/Dockerfile
+++ b/tutorbackup/templates/backup/build/backup/Dockerfile
@@ -1,13 +1,15 @@
-FROM python:3.8-buster
+FROM docker.io/ubuntu:20.04
 ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update && \
+    apt-get install -y curl gnupg
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.2.asc | gpg --dearmor | tee /usr/share/keyrings/mongodb-ce-archive-keyring.gpg && \
+    echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-ce-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends mysql-client-8.0 mongodb-org-tools python3-pip python3-venv python-is-python3
 RUN python3 -m venv /s3/venv/
 ENV PATH "/s3/venv/bin:$PATH"
-
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.2.asc | gpg --dearmor | tee /usr/share/keyrings/mongodb-ce-archive-keyring.gpg && \
-    echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-ce-archive-keyring.gpg] https://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends default-mysql-client mongodb-org-tools && \
-    pip install --upgrade pip && \
+RUN pip install --upgrade pip && \
     pip install boto3 click && \
     mkdir data backup
 

--- a/tutorbackup/templates/backup/build/backup/Dockerfile
+++ b/tutorbackup/templates/backup/build/backup/Dockerfile
@@ -3,8 +3,8 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && \
     apt-get install -y curl gnupg
-RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.2.asc | gpg --dearmor | tee /usr/share/keyrings/mongodb-ce-archive-keyring.gpg && \
-    echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-ce-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list && \
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | gpg --dearmor > /usr/share/keyrings/mongodb-ce-archive-keyring.gpg && \
+    echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-ce-archive-keyring.gpg] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends mysql-client-8.0 mongodb-org-tools python3-pip python3-venv python-is-python3
 RUN python3 -m venv /s3/venv/


### PR DESCRIPTION
Bring things in line with Tutor itself: 

* Use an Ubuntu base image instead of the Debian-based upstream Python image.
* Install the MySQL client utilities (including `mysqldump`) using the `mysql-client-8.0` Ubuntu package.
* Bump the MongoDB clients to version 4.4.