### PR TITLE
fix: Flush logs after MySQL restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## Unreleased
+
+* [fix] Run `mysqladmin flush-logs` immediately after a successful
+  MySQL restore.
+
 ## Version 3.0.0 (2023-10-27)
 
-* [fix]: Switch the MySQL client tools to version 8.0 and the MongoDB
+* [fix] Switch the MySQL client tools to version 8.0 and the MongoDB
   client tools to version 4.4.
 
 This version drops compatibility with Open edX Olive and Tutor 15.

--- a/tutorbackup/templates/backup/build/backup/restore_services.py
+++ b/tutorbackup/templates/backup/build/backup/restore_services.py
@@ -43,17 +43,27 @@ def restore_mysql():
     dump_file = MYSQL_DUMPFILE
 
     logger.info(f"Restoring MySQL databases on {host}:{port} from {dump_file}")
-    cmd = ("mysql "
-           f"--host={host} --port={port} "
-           f"--user={user} --password={password}")
+    mysql_cmd = ("mysql "
+                 f"--host={host} --port={port} "
+                 f"--user={user} --password={password}")
     with open(dump_file, 'rb') as dump:
-        check_call(cmd,
+        check_call(mysql_cmd,
                    shell=True,
                    stdin=dump,
                    stdout=sys.stdout,
                    stderr=sys.stderr)
-
     logger.info("MySQL restored.")
+
+    logger.info(f"Flushing logs on {host}:{port}")
+    mysqladmin_cmd = ("mysqladmin "
+                      f"--host={host} --port={port} "
+                      f"--user={user} --password={password} "
+                      "flush-logs")
+    check_call(mysqladmin_cmd,
+               shell=True,
+               stdout=sys.stdout,
+               stderr=sys.stderr)
+    logger.info("Logs flushed.")
 
 
 def restore_mongodb():


### PR DESCRIPTION
If we are restoring a large database, the large amount of statements executed my importing a mysqldump may lead to a considerable number of binlog entries. Afterwards, it is usually prudent to have MySQL remove expired binlog files. One way to force MySQL into doing that is to flush logs.

Thus, add a `mysqladmin flush-logs` command right after successfully completing a restore.
