### PR TITLE
feat: Add options to opt-out single-transaction and flush logs in mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Add options to opt-out single-transaction and flush logs in mysql
+
 ## Version 3.2.0 (2024-04-05)
 * [Enhancement] Support Python 3.12.
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,27 @@ If your MongoDB instance uses an authentication database name other
 than `admin`, make sure you provide that with
 `BACKUP_MONGODB_AUTHENTICATION_DATABASE`.
 
+
+## Opting out single-transaction and flush logs
+
+In certain cloud MySQL services, like AWS Aurora, it might be forbidden
+even for the root user to lock the database.
+In these cases you might get errors like `Couldn't execute 'FLUSH TABLES 
+WITH READ LOCK': Access denied for user`. 
+This is caused by using the `single-transaction` option in mysql dumps and 
+flushing logs after restoring.
+
+To overcome these issues you can now set `BACKUP_MYSQL_SINGLE_TRANSACTION` 
+and `BACKUP_MYSQL_FLUSH_LOGS` to `false`. Both values are `true` by default.
+`BACKUP_MYSQL_SINGLE_TRANSACTION` controls the use of `--single-transaction` 
+option in the `mysqldump` command, while `BACKUP_MYSQL_FLUSH_LOGS` prevents
+issuing the `mysqladmin flush-logs` after restoring the DB.
+
+Please note that doing this will cause the MySQL db to be dumped without 
+locking the tables, which might result in corrupted backup archives.
+If you set `BACKUP_MYSQL_FLUSH_LOGS` to `false` we recommend to stop all services 
+before starting the backup process.
+
 ## Using this plugin with service version upgrades
 
 In general, you should be able to use this plugin even when you are

--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -31,6 +31,10 @@ spec:
               value: '{{ MYSQL_ROOT_USERNAME }}'
             - name: MYSQL_ROOT_PASSWORD
               value: '{{ MYSQL_ROOT_PASSWORD }}'
+            - name: MYSQL_SINGLE_TRANSACTION
+              value: "{{ BACKUP_MYSQL_SINGLE_TRANSACTION }}"
+            - name: MYSQL_FLUSH_LOGS
+              value: "{{ BACKUP_MYSQL_FLUSH_LOGS }}"
             {% if BACKUP_MYSQL_DATABASES %}
             - name: MYSQL_DATABASES
               value: {{ BACKUP_MYSQL_DATABASES | join(" ") }}
@@ -139,6 +143,10 @@ spec:
                   value: '{{ MYSQL_ROOT_USERNAME }}'
                 - name: MYSQL_ROOT_PASSWORD
                   value: '{{ MYSQL_ROOT_PASSWORD }}'
+                - name: MYSQL_SINGLE_TRANSACTION
+                  value: "{{ BACKUP_MYSQL_SINGLE_TRANSACTION }}"
+                - name: MYSQL_FLUSH_LOGS
+                  value: "{{ BACKUP_MYSQL_FLUSH_LOGS }}"
                 {% if BACKUP_MYSQL_DATABASES %}
                 - name: MYSQL_DATABASES
                   value: {{ BACKUP_MYSQL_DATABASES | join(" ") }}
@@ -246,6 +254,10 @@ spec:
                   value: '{{ MYSQL_ROOT_USERNAME }}'
                 - name: MYSQL_ROOT_PASSWORD
                   value: '{{ MYSQL_ROOT_PASSWORD }}'
+                - name: MYSQL_SINGLE_TRANSACTION
+                  value: "{{ BACKUP_MYSQL_SINGLE_TRANSACTION }}"
+                - name: MYSQL_FLUSH_LOGS
+                  value: "{{ BACKUP_MYSQL_FLUSH_LOGS }}"
                 {% if BACKUP_MYSQL_DATABASES %}
                 - name: MYSQL_DATABASES
                   value: {{ BACKUP_MYSQL_DATABASES | join(" ") }}

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -40,6 +40,8 @@ config = {
         "MONGODB_DATABASES": [],
         "MONGODB_AUTHENTICATION_DATABASE": "admin",
         "MONGORESTORE_ADDITIONAL_OPTIONS": "",
+        "MYSQL_SINGLE_TRANSACTION": True,
+        "MYSQL_FLUSH_LOGS": True,
     }
 }
 


### PR DESCRIPTION
In certain cloud DB services where it's not possible to lock the DB, the single-transaction option in mysql dumps and flushing logs after restoring will fail. For these cases, you can now set BACKUP_MYSQL_SINGLE_TRANSACTION and BACKUP_MYSQL_FLUSH_LOGS to false. Fixes: #77