### PR TITLE
feat: Add support for Tutor 18 / Open edX Redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* [Enhancement] Support Tutor 18 and Open edX Redwood.
 * [Enhancement] Add options to opt-out single-transaction and flush logs in mysql
 
 ## Version 3.2.0 (2024-04-05)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ appropriate one:
 | Olive            | `>=15.0, <16`     | `main`        | 2.x.x          |
 | Palm             | `>=16.0, <17`     | `main`        | 3.x.x          |
 | Quince           | `>=17.0, <18`     | `main`        | 3.x.x          |
+| Redwood          | `>=18.0, <19`     | `main`        | 3.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
     later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <18, >=16.0.0"],
+    install_requires=["tutor <19, >=16.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
* Update the install_requires list to support Tutor 18.
* Update the compatibility matrix in the README accordingly.