### PR TITLE
feat: Allow to override the base image for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Allow to override the Dockerfile base image. 
+
 ## Version 4.1.0 (2025-01-03)
 
 * [Enhancement] Support Tutor 19 and Open edX Sumac.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ This prevents your users from encountering errors during the restore process.
 
 ### General options
 
+* `BACKUP_BASE_IMAGE` (default: `docker.io/ubuntu:22.04`)
 * `BACKUP_DOCKER_IMAGE` (default: `<DOCKER_REGISTRY>backup:v4.1.0`, relative to `DOCKER_REGISTRY` as defined by the global Tutor option)
 
 ### Kubernetes options

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -16,6 +16,7 @@ from tutor.commands.k8s import k8s as k8s_command_group, K8sTaskRunner
 config = {
     "defaults": {
         "VERSION": __version__,
+        "BASE_IMAGE": "docker.io/ubuntu:22.04",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}backup:{{ BACKUP_VERSION }}",  # noqa: E501
         "K8S_CRONJOB_HISTORYLIMIT_FAILURE": 1,
         "K8S_CRONJOB_HISTORYLIMIT_SUCCESS": 3,

--- a/tutorbackup/templates/backup/build/backup/Dockerfile
+++ b/tutorbackup/templates/backup/build/backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:22.04
+FROM {{ BACKUP_BASE_IMAGE }}
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && \


### PR DESCRIPTION
Add a config option `BACKUP_BASE_IMAGE` that allows to override the base image for builds.