### PR TITLE
feat: Support latest version of boto3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* [Enhancement] Support latest versions of boto3; include the 
+  `BACKUP_S3_REQUEST_CHECKSUM_CALCULATION` configuration option. 
+  Defaults to the value of `S3_REQUEST_CHECKSUM_CALCULATION` as set by the `s3` plugin.
+
 ## Version 4.2.0 (2025-04-15)
 
 * [Enhancement] Allow to override the Dockerfile base image. 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ your backup storage, change these configuration parameters:
 * `BACKUP_S3_ACCESS_KEY` (default: `"{{ OPENEDX_AWS_ACCESS_KEY }}"`)
 * `BACKUP_S3_SECRET_ACCESS_KEY` (default: `"{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}"`)
 * `BACKUP_S3_BUCKET_NAME` (default: `"backups"`)
+* `BACKUP_S3_REQUEST_CHECKSUM_CALCULATION` (default: `"when_required"`)
 
 These values can be modified with `tutor config save --set
 PARAM_NAME=VALUE` commands.

--- a/tutorbackup/patches/k8s-jobs
+++ b/tutorbackup/patches/k8s-jobs
@@ -63,6 +63,8 @@ spec:
               value: '{{ BACKUP_S3_REGION_NAME }}'
             - name: S3_USE_SSL
               value: '{{ BACKUP_S3_USE_SSL }}'
+            - name: S3_REQUEST_CHECKSUM_CALCULATION
+              value: '{{ BACKUP_S3_REQUEST_CHECKSUM_CALCULATION }}'
             {% if BACKUP_S3_HOST %}- name: S3_ENDPOINT_URL
               value: '{{ "https" if BACKUP_S3_USE_SSL else "http" }}://{{ BACKUP_S3_HOST }}{% if BACKUP_S3_PORT %}:{{ BACKUP_S3_PORT }}{% endif %}'{% endif %}
             - name: S3_ACCESS_KEY
@@ -173,6 +175,8 @@ spec:
                   value: '{{ BACKUP_S3_REGION_NAME }}'
                 - name: S3_USE_SSL
                   value: '{{ BACKUP_S3_USE_SSL }}'
+                - name: S3_REQUEST_CHECKSUM_CALCULATION
+                  value: '{{ BACKUP_S3_REQUEST_CHECKSUM_CALCULATION }}'
                 {% if BACKUP_S3_HOST %}- name: S3_ENDPOINT_URL
                   value: '{{ "https" if BACKUP_S3_USE_SSL else "http" }}://{{ BACKUP_S3_HOST }}{% if BACKUP_S3_PORT %}:{{ BACKUP_S3_PORT }}{% endif %}'{% endif %}
                 - name: S3_ACCESS_KEY
@@ -286,6 +290,8 @@ spec:
                   value: '{{ BACKUP_S3_REGION_NAME }}'
                 - name: S3_USE_SSL
                   value: '{{ BACKUP_S3_USE_SSL }}'
+                - name: S3_REQUEST_CHECKSUM_CALCULATION
+                  value: '{{ BACKUP_S3_REQUEST_CHECKSUM_CALCULATION }}'
                 {% if BACKUP_S3_HOST %}- name: S3_ENDPOINT_URL
                   value: '{{ "https" if BACKUP_S3_USE_SSL else "http" }}://{{ BACKUP_S3_HOST }}{% if BACKUP_S3_PORT %}:{{ BACKUP_S3_PORT }}{% endif %}'{% endif %}
                 - name: S3_ACCESS_KEY

--- a/tutorbackup/plugin.py
+++ b/tutorbackup/plugin.py
@@ -37,6 +37,7 @@ config = {
         "S3_ACCESS_KEY": "{{ OPENEDX_AWS_ACCESS_KEY }}",
         "S3_SECRET_ACCESS_KEY": "{{ OPENEDX_AWS_SECRET_ACCESS_KEY }}",
         "S3_BUCKET_NAME": "backups",
+        "S3_REQUEST_CHECKSUM_CALCULATION": "{{ S3_REQUEST_CHECKSUM_CALCULATION | default('when_required') }}",  # noqa: E501
         "MYSQL_DATABASES": [],
         "MONGODB_DATABASES": [],
         "MONGODB_AUTHENTICATION_DATABASE": "admin",

--- a/tutorbackup/templates/backup/build/backup/s3_client.py
+++ b/tutorbackup/templates/backup/build/backup/s3_client.py
@@ -5,6 +5,7 @@ from botocore.config import Config
 
 
 config = Config(
+    request_checksum_calculation=os.environ['S3_REQUEST_CHECKSUM_CALCULATION'],
     signature_version=os.environ['S3_SIGNATURE_VERSION'],
     s3={
         'addressing_style': os.environ['S3_ADDRESSING_STYLE'],


### PR DESCRIPTION
Include the `request_checksum_calculation` config option to make sure backups can be uploaded to s3 with boto3 >= 1.37.34.