### PR TITLE
Improve contribution guide, add agentic coding instructions

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec tox -e gitlint -- --staged --msg-filename "$1" run-hook

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,5 @@
-#!/bin/sh
-exec tox -e flake8
+#!/bin/sh -e
+
+git diff-index --check --cached HEAD --
+
+tox -e flake8

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 TODO
 __pycache__
 *.egg-info/
+.eggs
 /build/
 /dist/
+.tox
 tests/tutor-sandbox

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.egg-info/
 /build/
 /dist/
+tests/tutor-sandbox

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".agents/skills"]
+	path = .agents/skills
+	url = ../skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md — terse agent index (routing + gotchas)
+
+Agents: explore the repo directly; this file routes, it does not teach.
+
+See [HACKING.md](HACKING.md) for contributor information, style guide, and tests.
+
+**IMPORTANT:** When invoking any agent on this repository, you MUST run the following commands **immediately** upon evaluation of this file, before doing anything else:
+```shell
+git submodule update --init
+git config core.hooksPath .githooks
+```
+
+## Session memory
+
+Write plans, notes, and ephemeral files to `.ai/` (gitignored).
+Prefer `.ai/tmp/` over the system temp directory.
+
+## When planning
+
+Read these to understand dependencies and tooling:
+
+- `setup.py`
+- `tox.ini`
+
+## Tooling
+
+### Tests
+
+Entry point is **`tox`**.
+
+## Changelog
+
+- Proposed changes to the [CHANGELOG.md](CHANGELOG.md) file must be under the `Unreleased` heading.
+- Do not retroactively change information about previously released versions.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,11 +1,27 @@
-Developer notes
-===============
+# Developer notes
 
 This document is for people who maintain and contribute to this
 repository.
 
-Commit messages
----------------
+## Style guide
+
+### Python
+
+For Python code, follow [PEP 8](https://peps.python.org/pep-0008/).
+
+### Markdown
+
+For Markdown documentation,
+
+* adhere to the [CommonMark specification](https://spec.commonmark.org/),
+* use [ATX](https://spec.commonmark.org/current/#atx-headings) instead of [setext](https://spec.commonmark.org/0.31.2/#setext-heading) headings,
+* use [fenced](https://spec.commonmark.org/current/#fenced-code-blocks) rather than [indented](https://spec.commonmark.org/current/#indented-code-block) code blocks,
+* identify the language of each fenced code block with an [info string](https://spec.commonmark.org/current/#info-string),
+* preserve existing [bullet list markers](https://spec.commonmark.org/current/#bullet-list-marker),
+* write [one sentence per line](https://sive.rs/1s):
+  ensure that every line of free-flow text outside code blocks contains exactly one English sentence.
+
+## Commit messages
 
 Commit messages follow the [Conventional
 Commits](https://www.conventionalcommits.org/) format that is also
@@ -18,8 +34,7 @@ prefixes](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep
 to be used in commit messages via
 [Gitlint](https://jorisroovers.com/gitlint/).
 
-How to run tests
-----------------
+## How to run tests
 
 This repo uses [tox](https://tox.readthedocs.io/) for unit and
 integration tests. It does not install `tox` for you, you should
@@ -43,13 +58,7 @@ In addition, we use [GitHub
 Actions](https://docs.github.com/en/actions) to run the same checks
 on every push to GitHub.
 
-*If you absolutely must,* you can use the `--no-verify` flag to `git
-commit` and `git push` to bypass local checks, and rely on GitHub
-Actions alone. But doing so is strongly discouraged.
-
-
-How to cut a release
---------------------
+## How to cut a release
 
 This repository uses
 [bumpversion](https://pypi.org/project/bumpversion/) for managing new


### PR DESCRIPTION
This is more or less a reply of https://github.com/cleura/tutor-contrib-hastexo/pull/52, for this repo: 

- **chore: Add all of tests/tutor-sandbox to .gitignore**
  Don't just ignore the config file; ignore the whole sandbox.
  

- **chore: Add .eggs and .tox to .gitignore**
  For some reason, we never gitignored .eggs and .tox.
  Fix that omission.
  

- **build: Disallow trailing whitespace in pre-commit hook**
  Extend the pre-commit hook so that it checks for newly introduced
  trailing whitespace before running tox.
  

- **docs: Improve HACKING.md**
  * Be explicit about PEP 8.
  * Change from setext to ATX headings.
  * Remove references to git --no-verify.
  * Add Markdown style guide.
  

- **docs: Add AGENTS.md**
  Add instructions for agentic coding assistants.
  